### PR TITLE
Param detection

### DIFF
--- a/src/mic/click_encapsulate/commands.py
+++ b/src/mic/click_encapsulate/commands.py
@@ -154,14 +154,13 @@ def trace(command, c, o):
     type=click.Path(exists=True, dir_okay=False, file_okay=True, resolve_path=True),
     default=CONFIG_YAML_NAME
 )
-@click.option('--autoparam/--no-autoparam', default=True, help="Enable or disable automatic detection of parameters"
-                                                                 " from config file")
-def configs(mic_file, configuration_files,autoparam):
+@click.option('-a', '--auto_param', is_flag=True, default=False, help="Enable automatic detection of parameters from "
+                                                                      "config file")
+def configs(mic_file, configuration_files,auto_param):
     """
     If your model does not use configuration files, you can skip this step
 
-    Specify the inputs and parameters of your model component from configuration file(s). Running mic encapsulate inputs
-    before this command will ensure inputs don't get auto detected as parameters
+    Specify the inputs and parameters of your model component from configuration file(s).
 
     - You must pass the MIC_FILE (mic.yaml) using the option (-f) or run the command from the same directory as mic.yaml
 
@@ -187,7 +186,7 @@ def configs(mic_file, configuration_files,autoparam):
         click.secho("Failed: Error message {}".format(e), fg="red")
     for item in configuration_files:
         click.secho("Added: {} as a configuration file".format(item))
-        if autoparam:
+        if auto_param:
             # Parse parameters from config file(s) and add them to mic.yaml
             add_params_from_config(mic_config_file, item)
 

--- a/src/mic/click_encapsulate/commands.py
+++ b/src/mic/click_encapsulate/commands.py
@@ -160,7 +160,8 @@ def configs(mic_file, configuration_files,autoparam):
     """
     If your model does not use configuration files, you can skip this step
 
-    Specify the inputs and parameters of your model component from configuration file(s)
+    Specify the inputs and parameters of your model component from configuration file(s). Running mic encapsulate inputs
+    before this command will ensure inputs don't get auto detected as parameters
 
     - You must pass the MIC_FILE (mic.yaml) using the option (-f) or run the command from the same directory as mic.yaml
 

--- a/src/mic/config_yaml.py
+++ b/src/mic/config_yaml.py
@@ -226,7 +226,7 @@ def add_params_from_config(yaml_path: Path, config_path: Path):
         if PARAMETERS_KEY not in mic_yaml:
             mic_yaml[PARAMETERS_KEY] = {}
 
-        if name not in mic_yaml[PARAMETERS_KEY]:
+        if name not in mic_yaml[PARAMETERS_KEY] and name not in mic_yaml[INPUTS_KEY]:
             mic_yaml[PARAMETERS_KEY].update({name: {DEFAULT_VALUE_KEY: 0}})
             click.secho("Automatically adding \"{}\" as a parameter".format(name))
             added = True

--- a/src/mic/config_yaml.py
+++ b/src/mic/config_yaml.py
@@ -199,6 +199,41 @@ def add_outputs(config_yaml_path: Path, outputs: List[Path]):
     for item in spec[OUTPUTS_KEY]:
         click.secho("Added: {} as a output".format(item))
 
+def add_params_from_config(yaml_path: Path, config_path: Path):
+    """
+    Add parameters to the mic.yaml file from the user's config file. Looks for ${var_name} in config file and
+    adds the var_name as parameter to yaml
+
+    @param yaml_path: path to mic.yaml file
+    @type yaml_path: Path
+    @param config_path: path to user's config file
+    @type config_path: Path
+    """
+    mic_yaml = yaml.load(yaml_path.open(), Loader=Loader)
+    var_list = []
+    with open(config_path, "r") as f:
+        file = f.readlines()
+        for line in file:
+
+            if "${" in line and "}" in line:
+                tmp = line[line.find("${")+2:line.find("}")]
+                var_list.append(tmp)
+
+    # Add the var names as parameters
+    added = False
+    for name in var_list:
+
+        if PARAMETERS_KEY not in mic_yaml:
+            mic_yaml[PARAMETERS_KEY] = {}
+
+        if name not in mic_yaml[PARAMETERS_KEY]:
+            mic_yaml[PARAMETERS_KEY].update({name: {DEFAULT_VALUE_KEY: 0}})
+            click.secho("Automatically adding \"{}\" as a parameter".format(name))
+            added = True
+        write_spec(Path(yaml_path), PARAMETERS_KEY, mic_yaml[PARAMETERS_KEY])
+
+    if added:
+        click.secho("Default values will need to be added in {} for each parameter".format(CONFIG_YAML_NAME),fg="green")
 
 def get_inputs_parameters(config_yaml_path: Path) -> (dict, dict, dict):
     inputs = get_inputs(config_yaml_path)

--- a/src/mic/config_yaml.py
+++ b/src/mic/config_yaml.py
@@ -226,10 +226,16 @@ def add_params_from_config(yaml_path: Path, config_path: Path):
         if PARAMETERS_KEY not in mic_yaml:
             mic_yaml[PARAMETERS_KEY] = {}
 
-        if name not in mic_yaml[PARAMETERS_KEY] and name not in mic_yaml[INPUTS_KEY]:
-            mic_yaml[PARAMETERS_KEY].update({name: {DEFAULT_VALUE_KEY: 0}})
-            click.secho("Automatically adding \"{}\" as a parameter".format(name))
-            added = True
+        if name not in mic_yaml[PARAMETERS_KEY]:
+            if INPUTS_KEY not in mic_yaml:
+                mic_yaml[PARAMETERS_KEY].update({name: {DEFAULT_VALUE_KEY: 0}})
+                click.secho("Automatically adding \"{}\" as a parameter".format(name))
+                added = True
+            elif name not in mic_yaml[INPUTS_KEY]:
+                mic_yaml[PARAMETERS_KEY].update({name: {DEFAULT_VALUE_KEY: 0}})
+                click.secho("Automatically adding \"{}\" as a parameter".format(name))
+                added = True
+                
         write_spec(Path(yaml_path), PARAMETERS_KEY, mic_yaml[PARAMETERS_KEY])
 
     if added:

--- a/src/mic/config_yaml.py
+++ b/src/mic/config_yaml.py
@@ -226,16 +226,29 @@ def add_params_from_config(yaml_path: Path, config_path: Path):
         if PARAMETERS_KEY not in mic_yaml:
             mic_yaml[PARAMETERS_KEY] = {}
 
+        not_input = False
+        not_output = False
+        not_config = False
+
         if name not in mic_yaml[PARAMETERS_KEY]:
             if INPUTS_KEY not in mic_yaml:
-                mic_yaml[PARAMETERS_KEY].update({name: {DEFAULT_VALUE_KEY: 0}})
-                click.secho("Automatically adding \"{}\" as a parameter".format(name))
-                added = True
+                not_input = True
             elif name not in mic_yaml[INPUTS_KEY]:
+                not_input = True
+            if OUTPUTS_KEY not in mic_yaml:
+                not_output = True
+            elif name not in mic_yaml[OUTPUTS_KEY]:
+                not_output = True
+            if CONFIG_FILE_KEY not in mic_yaml:
+                not_config = True
+            elif name not in mic_yaml[CONFIG_FILE_KEY]:
+                not_config = True
+
+            if not_input and not_output and not_config:
                 mic_yaml[PARAMETERS_KEY].update({name: {DEFAULT_VALUE_KEY: 0}})
                 click.secho("Automatically adding \"{}\" as a parameter".format(name))
                 added = True
-                
+
         write_spec(Path(yaml_path), PARAMETERS_KEY, mic_yaml[PARAMETERS_KEY])
 
     if added:

--- a/src/mic/tests/test_config_yaml.py
+++ b/src/mic/tests/test_config_yaml.py
@@ -1,6 +1,6 @@
 import shutil
 from pathlib import Path
-
+import os
 from click.testing import CliRunner
 from mic.click_encapsulate.commands import inputs, outputs, wrapper
 from mic.config_yaml import get_outputs_mic, get_parameters, get_inputs_parameters, get_configs
@@ -37,6 +37,8 @@ def test_get_inputs_parameters():
                                             {'config_json': {'format': 'json', 'path': 'config.json'}})
     assert get_inputs_parameters(mic_empty) == ({}, {}, {}, {})
 
+# def test_auto_parameters():
+#     os.mkdir("")
 
 def test_issue_168(tmp_path):
     test_name = "issue_168"


### PR DESCRIPTION
Automatically detect parameters from config.json and add them to mic.yaml. 
Added option `--autoparam/--no-autoparam` to disable automatic parameter detection
Fix: #160 
Example: 
```json
chris@chris-ubuntu20:/home/chris/Desktop/tests/simpleModel  (master)$ cat config.json 
{
"input" :
  {
  "dataset_name" : "${x_csv}"
},
"output" :
  {
  "path" : "./"
},
"params" :
  {
  "a" : "${a}",
  "b" : "${b}",
  "c" : "${c}"
  }
}
```
```yaml
chris@chris-ubuntu20:/home/chris/Desktop/tests/simpleModel  (master)$ cat mic/mic.yaml 
step: 2
name: csa
configs:
  config_json:
    path: config.json
    format: json
inputs:
  x_csv:
    path: x.csv
    format: csv
  results_zip:
    path: results.zip
    format: zip
code_files:
  linemodel_py:
    path: linemodel.py
    format: py
```
```
chris@chris-ubuntu20:/home/chris/Desktop/tests/simpleModel  (master)$ mic encapsulate configs config.json -f mic/mic.yaml 
Added: /home/chris/Desktop/tests/simpleModel/config.json as a configuration file
Automatically adding "a" as a parameter
Automatically adding "b" as a parameter
Automatically adding "c" as a parameter
Default values will need to be added in mic.yaml for each parameter
```
```yaml
chris@chris-ubuntu20:/home/chris/Desktop/tests/simpleModel  (master)$ cat mic/mic.yaml 
step: 2
name: csa
configs:
  config_json:
    path: config.json
    format: json
inputs:
  x_csv:
    path: x.csv
    format: csv
  results_zip:
    path: results.zip
    format: zip
code_files:
  linemodel_py:
    path: linemodel.py
    format: py
parameters:
  a:
    default_value: 0
  b:
    default_value: 0
  c:
    default_value: 0
```
`a`, `b`, and `c` all get detected as parameters but `x_csv` gets ignored since it is already declared as an input 