### PR TITLE
Fix: use shlex instead of split by space to keep quoted strings

### DIFF
--- a/src/mic/component/executor.py
+++ b/src/mic/component/executor.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import shlex
 import subprocess
 from pathlib import Path
 from mic._utils import get_mic_logger
@@ -46,7 +47,12 @@ Destination: {src_executions_dir}""")
 
 
 def run_execution(line, execution_dir):
-    proc = subprocess.Popen(line.split(' '), cwd=execution_dir)
+
+    # Splits by white space keeping things in quotes
+    exe_arr = shlex.split(line)
+
+    logging.debug("exe_arr: {}".format(exe_arr))
+    proc = subprocess.Popen(exe_arr, cwd=execution_dir)
     proc.wait()
     return proc.returncode
 
@@ -54,10 +60,13 @@ def run_execution(line, execution_dir):
 def execute_local(mint_config_file: Path, execution_name):
     execution_dir = create_execution_directory(mint_config_file, execution_name)
     resource = create_model_catalog_resource(mint_config_file, name=None, execution_dir=execution_dir)
+
     try:
         line = get_command_line(resource)
     except:
         logging.error("Unable to cmd_line", exc_info=True)
+
+    logging.info("Running: {}".format(line))
     click.secho("Running\n{}".format(line))
     if run_execution(line, execution_dir) == 0:
         return True

--- a/src/mic/component/reprozip.py
+++ b/src/mic/component/reprozip.py
@@ -75,7 +75,16 @@ def get_outputs_reprozip(spec, user_execution_directory, aggregrate=False):
 def get_parameters_reprozip(spec, reprozip_spec):
     run_lines = ''
     for rep_run in reprozip_spec[REPRO_ZIP_RUNS]:
-        run_lines = shlex.join(map(str, rep_run[REPRO_ZIP_ARGV])).splitlines()
+
+        # Adds quotes around any cell that contains a space
+        quoted_run = []
+        for i in rep_run[REPRO_ZIP_ARGV]:
+            if " " in i:
+                quoted_run.append("\"" + i + "\"")
+            else:
+                quoted_run.append(i)
+
+        run_lines = " ".join(map(str, quoted_run)).splitlines()
 
     params_added = 0
     for line in run_lines:
@@ -150,7 +159,16 @@ def generate_runner(spec, user_execution_directory, mic_inputs, mic_outputs, mic
     code = ''
 
     for run in spec[REPRO_ZIP_RUNS]:
-        code_line = shlex.join(map(str, run[REPRO_ZIP_ARGV]))
+
+        # Adds quotes around any cell that contains a space
+        quoted_run = []
+        for i in run[REPRO_ZIP_ARGV]:
+            if " " in i:
+                quoted_run.append("\"" + i + "\"")
+            else:
+                quoted_run.append(i)
+
+        code_line = ' '.join(map(str, quoted_run))
         code_line = format_code(code_line, mic_inputs, mic_outputs, mic_parameters)
         dir_ = str(Path(run[REPRO_ZIP_WORKING_DIR]).relative_to(default_path))
         code = f"""{code}

--- a/src/mic/tests/resources/254/.reprozip-trace2/config.yml
+++ b/src/mic/tests/resources/254/.reprozip-trace2/config.yml
@@ -13,7 +13,10 @@ runs:
   - in.txt
   - '15'
   - hello
-  - '3.1415'
+  - '-3.1415'
+  - '-15'
+  - 'test.txt'
+  - 'string-special'
   binary: /bin/sh
   distribution:
   - ubuntu

--- a/src/mic/tests/resources/254/mic/mic3.yaml
+++ b/src/mic/tests/resources/254/mic/mic3.yaml
@@ -33,6 +33,21 @@ parameters:
     description: ''
   param_3:
     name: ''
-    default_value: '3.1415'
+    default_value: '-3.1415'
     type: float
+    description: ''
+  param_4:
+    name: ''
+    default_value: '-15'
+    type: int
+    description: ''
+  param_5:
+    name: ''
+    default_value: 'test.txt'
+    type: str
+    description: ''
+  param_6:
+    name: ''
+    default_value: 'string-special'
+    type: str
     description: ''

--- a/src/mic/tests/test_parameters.py
+++ b/src/mic/tests/test_parameters.py
@@ -61,7 +61,7 @@ def test_wrapper_code():
     params = get_parameters(Path(__file__).parent / RESOURCES / mic_yaml)
 
     code = generate_runner(repro_spec, DEFAULT_PATH, inp, outp, params)
-    assert code == "\npushd .\n/bin/sh ./addtoarray.sh ${a_txt} ${in_txt} ${param_1} ${param_2} ${param_3}\npopd"
+    assert code == "\npushd .\n/bin/sh ./addtoarray.sh ${a_txt} ${in_txt} ${param_1} \"${param_2}\" ${param_3}\npopd"
 
 #
 #

--- a/src/mic/tests/test_parameters.py
+++ b/src/mic/tests/test_parameters.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 
-from mic.component.reprozip import get_outputs_reprozip, get_inputs_outputs_reprozip, generate_runner, \
-    generate_pre_runner, get_parameters_reprozip
+from mic.component.reprozip import generate_runner, \
+    get_parameters_reprozip
 from mic.config_yaml import get_spec, get_inputs, get_outputs_mic, get_parameters
 
 RESOURCES = "resources"
 DEFAULT_PATH = Path("/tmp/mint/")
 
 
-#Test that mic can detect parameters from trace command
+# Test that mic can detect parameters from trace command
 def test_param_detection():
     mic_yaml = Path("254/mic/mic.yaml")
     mic_spec = get_spec(Path(__file__).parent / RESOURCES / mic_yaml)
@@ -22,11 +22,12 @@ def test_param_detection():
     assert spec == {"step": 1,
                     "name": "test-autoparam",
                     "docker_image": "test-autoparam:latest",
-                    "inputs": {"a_txt": {"path": "a.txt","format": "txt"},
-                               "in_txt": {"path": "in.txt","format": "txt"}},
-                    "code_files": {"addtoarray_sh": {"path": "addtoarray.sh","format": "sh"}},
-                    "outputs": {"out_csv": {"path": "outputs/out.csv","format": "csv"}},
-                    "parameters": {"param_1": {"name": "","default_value": "15","type": "int","description": ""}}}
+                    "inputs": {"a_txt": {"path": "a.txt", "format": "txt"},
+                               "in_txt": {"path": "in.txt", "format": "txt"}},
+                    "code_files": {"addtoarray_sh": {"path": "addtoarray.sh", "format": "sh"}},
+                    "outputs": {"out_csv": {"path": "outputs/out.csv", "format": "csv"}},
+                    "parameters": {"param_1": {"name": "", "default_value": "15", "type": "int", "description": ""}}}
+
 
 def test_param_detection_v2():
     mic_yaml = Path("254/mic/mic2.yaml")
@@ -41,14 +42,19 @@ def test_param_detection_v2():
     assert spec == {"step": 1,
                     "name": "parameter-test",
                     "docker_image": "parameter-test:latest",
-                    "inputs": {"a_txt": {"path": "a.txt","format": "txt"},
-                               "in_txt": {"path": "in.txt","format": "txt"}},
-                    "code_files": {"addtoarray_sh": {"path": "addtoarray.sh","format": "sh"}},
-                    "outputs": {"out_csv": {"path": "outputs/out.csv","format": "csv"}},
+                    "inputs": {"a_txt": {"path": "a.txt", "format": "txt"},
+                               "in_txt": {"path": "in.txt", "format": "txt"}},
+                    "code_files": {"addtoarray_sh": {"path": "addtoarray.sh", "format": "sh"}},
+                    "outputs": {"out_csv": {"path": "outputs/out.csv", "format": "csv"}},
                     "parameters": {
-                        "param_1": {"name": "","default_value": "15","type": "int","description": ""},
-                        "param_2": {"name": "","default_value": "hello","type": "str","description": ""},
-                        "param_3": {"name": "","default_value": "3.1415","type": "float","description": ""}}}
+                        "param_1": {"name": "", "default_value": "15", "type": "int", "description": ""},
+                        "param_2": {"name": "", "default_value": "hello", "type": "str", "description": ""},
+                        "param_3": {"name": "", "default_value": "-3.1415", "type": "float", "description": ""},
+                        "param_4": {"name": "", "default_value": "-15", "type": "int", "description": ""},
+                        "param_5": {"name": "", "default_value": "test.txt", "type": "str", "description": ""},
+                        "param_6": {"name": "", "default_value": "string-special", "type": "str", "description": ""}
+                    }
+                    }
 
 def test_wrapper_code():
     mic_yaml = Path("254/mic/mic3.yaml")
@@ -130,5 +136,3 @@ def test_wrapper_code():
 #     yml = "mic_3.yaml"
 #     spec = get_spec(Path(__file__).parent / RESOURCES / yml)
 #     assert generate_pre_runner(spec, DEFAULT_PATH) == "\ncp -rv x.csv results/x.csv"
-
-

--- a/src/mic/tests/test_parameters.py
+++ b/src/mic/tests/test_parameters.py
@@ -67,7 +67,8 @@ def test_wrapper_code():
     params = get_parameters(Path(__file__).parent / RESOURCES / mic_yaml)
 
     code = generate_runner(repro_spec, DEFAULT_PATH, inp, outp, params)
-    assert code == "\npushd .\n/bin/sh ./addtoarray.sh ${a_txt} ${in_txt} ${param_1} \"${param_2}\" ${param_3}\npopd"
+    assert code == "\npushd .\n/bin/sh ./addtoarray.sh ${a_txt} ${in_txt} ${param_1} \"${param_2}\" ${param_3} " \
+                   "${param_4} \"${param_5}\" \"${param_6}\"\npopd"
 
 #
 #


### PR DESCRIPTION
- String parameters will be wrapped in quotes
- Auto param detection will ignore items on the invocation line that start with '-' (since many programs use command line options)
- Auto param detection will now detect quoted strings as one parameter