### PR TITLE
Fix: replace hyphens with underscore for yaml input direcory names

### DIFF
--- a/src/mic/component/executor.py
+++ b/src/mic/component/executor.py
@@ -17,7 +17,7 @@ def copy_file(input_path: Path, src_dir_path: Path):
 
 
 def compress_directory(directory_path: Path, working_dir):
-    zip_file_path = shutil.make_archive(directory_path.name, 'zip', root_dir=directory_path.parent,
+    zip_file_path = shutil.make_archive(directory_path.name.replace("-","_"), 'zip', root_dir=directory_path.parent,
                                         base_dir=directory_path.name)
     data_zip = working_dir / Path(zip_file_path).name
     shutil.move(zip_file_path, data_zip)


### PR DESCRIPTION
Forces a zip directory input to have underscores instead of hyphens in the yaml. This fixes a bug with the wrapper (io.sh specifically) where a hyphen in the name breaks the run command 